### PR TITLE
security: prevent reflected XSS via file parameter (serveimg.php)

### DIFF
--- a/disp/serveimg.php
+++ b/disp/serveimg.php
@@ -43,7 +43,7 @@ print "<div class=\"prevpage\">\n";
 genDisplayFile("&lt;",$fileprev);
 genDisplayFile("&gt;",$filenext);
 print "</div>\n";
-print "<img src=\"$filename\" />";
+print "<img src=\"" . htmlspecialchars($filename, ENT_QUOTES) . "\" />";
 #echo "</body></html>";
 exit;
 
@@ -51,7 +51,7 @@ function genDisplayFile($text,$file) {
  if ($file == '') {
   return;
  }
- $href ="serveimg.php?file=$file";
+ $href ="serveimg.php?file=" . urlencode($file);
  $a = "<a class=\"nppage\" onclick=\"displaylink('" . $href . "');\"><span class='nppage1'>$text</span></a>";
  print "$a\n";
 }

--- a/disp1/serveimg.php
+++ b/disp1/serveimg.php
@@ -33,14 +33,14 @@ print "<div class=\"prevpage\">\n";
 genDisplayFile("&lt;",$fileprev);
 genDisplayFile("&gt;",$filenext);
 print "</div>\n";
-print "<img src=\"$filename\" />";
+print "<img src=\"" . htmlspecialchars($filename, ENT_QUOTES) . "\" />";
 exit;
 
 function genDisplayFile($text,$file) {
  if ($file == '') {
   return;
  }
- $href ="serveimg.php?file=$file";
+ $href ="serveimg.php?file=" . urlencode($file);
  $a = "<a class=\"nppage\" onclick=\"displaylink('" . $href . "');\"><span class='nppage1'>$text</span></a>";
  print "$a\n";
 }


### PR DESCRIPTION
## Reflected XSS via `file` parameter

Both serve-image endpoints echoed the **raw** `$_GET['file']` into output:

- [`disp/serveimg.php`](https://github.com/sanskrit-lexicon/csl-kale/blob/master/disp/serveimg.php)
- [`disp1/serveimg.php`](https://github.com/sanskrit-lexicon/csl-kale/blob/master/disp1/serveimg.php)

```php
print "<img src=\"$filename\" />";                 // HTML-attribute context
$href ="serveimg.php?file=$file";                  // -> displaylink('...') JS context
```

`?file="><script>alert(1)</script>` breaks out of the `src` attribute, and the prev/next navigation reflects the same value into a `displaylink('...')` call. Either path executes arbitrary JavaScript.

## Fix

- `<img src>` — escape with `htmlspecialchars($filename, ENT_QUOTES)`.
- Navigation href — `urlencode($file)` the query-parameter value, which is safe in both the JS-string and HTML-attribute contexts and is decoded back to the same value server-side, so image navigation is unchanged.

`php -l` clean (PHP 8.2). These endpoints render an `<img>` tag (the browser loads the image) and do **not** read the file server-side, so this is purely reflected XSS.

## ⚠️ Separate finding — please review `disp1/unused_index1.php`

[`disp1/unused_index1.php`](https://github.com/sanskrit-lexicon/csl-kale/blob/master/disp1/unused_index1.php) (explicitly named *unused*) both reflects `$_GET['file']` (`echo "<p>file=".$filename`) **and** opens it server-side:

```php
$file = fopen($filename,"r") or exit("index1: Unable to open file $filename");
```

That is an **arbitrary local file read (LFI)** in addition to XSS. As the file is marked unused, the safest action is to **delete it** rather than patch dead code — left for a maintainer decision; not touched in this PR.

Part of the org-wide reflected-XSS / JSONP sweep (sanskrit-lexicon/csl-websanlexicon#27, #63, #67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)